### PR TITLE
Fix issue writing to std out

### DIFF
--- a/flup/server/fcgi_base.py
+++ b/flup/server/fcgi_base.py
@@ -369,7 +369,7 @@ class StdoutWrapper(object):
     def write(self, data):
         if data:
             self.dataWritten = True
-        self._file.buffer.write(data)
+        self._file.write(data)
 
     def writelines(self, lines):
         for line in lines:


### PR DESCRIPTION
buffer has been removed in python 3
Fix:
AttributeError: 'LogStdout' object has no attribute 'buffer'